### PR TITLE
Fix handling itemstacks that have data tags- they should never stack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>net.jimeowan</groupId>
     <artifactId>inventory-tweaks</artifactId>
-    <version>1.41b-1.2.4</version>
+    <version>1.42-1.2.5</version>
     <packaging>jar</packaging>
     <name>Inventory Tweaks</name>
 

--- a/src/InvTweaksContainerManager.java
+++ b/src/InvTweaksContainerManager.java
@@ -160,7 +160,9 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
         // Use intermediate slot if we have to swap tools, maps, etc.
         if (destStack != null
                 && getItemID(srcStack) == getItemID(destStack)
-                && getMaxStackSize(srcStack) == 1) {
+                && (getMaxStackSize(srcStack) == 1 ||
+                    hasDataTags(srcStack) || hasDataTags(destStack)
+                )) {
             int intermediateSlot = getFirstEmptyUsableSlotNumber();
             InvTweaksContainerSection intermediateSection = getSlotSection(intermediateSlot);
             int intermediateIndex = getSlotIndex(intermediateSlot);

--- a/src/InvTweaksHandlerShortcuts.java
+++ b/src/InvTweaksHandlerShortcuts.java
@@ -437,7 +437,7 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
             for (yu slot : container.getSlots(toSection)) {
                 if (hasStack(slot)) {
                     aan stack = getStack(slot);
-                    if (areItemsEqual(stack, fromStack)
+                    if (!hasDataTags(stack) && areItemsEqual(stack, fromStack)
                             && getStackSize(stack) < getMaxStackSize(stack)) {
                         result = i;
                         break;

--- a/src/InvTweaksHandlerSorting.java
+++ b/src/InvTweaksHandlerSorting.java
@@ -366,7 +366,7 @@ public class InvTweaksHandlerSorting extends InvTweaksObfuscation {
                     }
                 }
 
-                if (areItemsEqual(from, to)) {
+                if (!hasDataTags(from) && !hasDataTags(to) && areItemsEqual(from, to)) {
                     // Can be merged?
                     if (getStackSize(to) < getMaxStackSize(to)) {
                         canBeSwappedOrMerged = true;

--- a/src/InvTweaksObfuscation.java
+++ b/src/InvTweaksObfuscation.java
@@ -151,6 +151,9 @@ public class InvTweaksObfuscation {
 	protected int getMaxStackSize(aan itemStack) {
 		return itemStack.c();
 	}
+	protected boolean hasDataTags(aan itemStack) {
+	  return itemStack.n();
+	}
 	protected int getStackSize(aan itemStack) {
 		return itemStack.a;
 	}


### PR DESCRIPTION
Hi,
So, this fixes a problem with tfcraft and a couple of other mods that use "tags" on itemstacks to track various meta properties so they sort properly: basically, if it has a tag, it should never stack.

Hope this helps
