### PR TITLE
Mod Compatibility API Proposal

### DIFF
--- a/src/minecraft/invtweaks/InvTweaks.java
+++ b/src/minecraft/invtweaks/InvTweaks.java
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import invtweaks.api.InvTweaksContainerSection;
+import invtweaks.api.ContainerSection;
 import net.minecraft.client.Minecraft;
 import net.minecraft.src.GuiButton;
 import net.minecraft.src.GuiContainer;
@@ -189,7 +189,7 @@ public class InvTweaks extends InvTweaksObfuscation {
         }
 
         try {
-            InvTweaksContainerSectionManager containerMgr = new InvTweaksContainerSectionManager(mc, InvTweaksContainerSection.INVENTORY);
+            InvTweaksContainerSectionManager containerMgr = new InvTweaksContainerSectionManager(mc, ContainerSection.INVENTORY);
             containerMgr.setClickDelay(config.getClickDelay());
 
             // Find stack slot (look in hotbar only).
@@ -421,7 +421,7 @@ public class InvTweaks extends InvTweaksObfuscation {
         // Sorting
         try {
             new InvTweaksHandlerSorting(mc, cfgManager.getConfig(),
-                    InvTweaksContainerSection.INVENTORY,
+                    ContainerSection.INVENTORY,
                     InvTweaksHandlerSorting.ALGORITHM_INVENTORY,
                     InvTweaksConst.INVENTORY_ROW_SIZE).sort();
         } catch (Exception e) {
@@ -506,7 +506,7 @@ public class InvTweaks extends InvTweaksObfuscation {
                     InvTweaksContainerManager containerMgr = new InvTweaksContainerManager(mc);
                     containerMgr.setClickDelay(config.getClickDelay());
 					Slot slotAtMousePosition = containerMgr.getSlotAtMousePosition();
-                    InvTweaksContainerSection target = null;
+                    ContainerSection target = null;
                     if (slotAtMousePosition != null) {
                     	target = containerMgr.getSlotSection(getSlotNumber(slotAtMousePosition));
                     }
@@ -517,7 +517,7 @@ public class InvTweaks extends InvTweaksObfuscation {
                         // (copied GuiContainer.getSlotAtPosition algorithm)
                     	GuiContainer guiContainer = asGuiContainer(guiScreen);
 
-                        if (InvTweaksContainerSection.CHEST.equals(target)) {
+                        if (ContainerSection.CHEST.equals(target)) {
 
                             // Play click
                             playClick();
@@ -529,7 +529,7 @@ public class InvTweaks extends InvTweaksObfuscation {
                             }
                             try {
                                 new InvTweaksHandlerSorting(mc, cfgManager.getConfig(),
-                                        InvTweaksContainerSection.CHEST,
+                                        ContainerSection.CHEST,
                                         chestAlgorithm,
                                         getContainerRowSize(guiContainer)).sort();
                             } catch (Exception e) {
@@ -539,10 +539,10 @@ public class InvTweaks extends InvTweaksObfuscation {
                             chestAlgorithm = (chestAlgorithm + 1) % 3;
                             chestAlgorithmClickTimestamp = timestamp;
 
-                        } else if(InvTweaksContainerSection.CRAFTING_IN.equals(target)) {
+                        } else if(ContainerSection.CRAFTING_IN.equals(target)) {
                             try {
                                 new InvTweaksHandlerSorting(mc, cfgManager.getConfig(),
-                                        InvTweaksContainerSection.CRAFTING_IN,
+                                        ContainerSection.CRAFTING_IN,
                                         InvTweaksHandlerSorting.ALGORITHM_EVEN_STACKS,
                                         (containerMgr.getSize(target) == 9) ? 3 : 2).sort();
                             } catch(Exception e) {
@@ -550,16 +550,16 @@ public class InvTweaks extends InvTweaksObfuscation {
                                 e.printStackTrace();
                             }
 
-                        } else if (InvTweaksContainerSection.INVENTORY_HOTBAR.equals(target)
-                        		|| (InvTweaksContainerSection.INVENTORY_NOT_HOTBAR.equals(target))) {
+                        } else if (ContainerSection.INVENTORY_HOTBAR.equals(target)
+                        		|| (ContainerSection.INVENTORY_NOT_HOTBAR.equals(target))) {
                             handleSorting(guiScreen);
                         }
 
-                        if (InvTweaksContainerSection.CRAFTING_IN.equals(target)) {
+                        if (ContainerSection.CRAFTING_IN.equals(target)) {
                             // Crafting stacks evening
                             try {
                                 new InvTweaksHandlerSorting(mc, cfgManager.getConfig(),
-                                        InvTweaksContainerSection.CRAFTING_IN,
+                                        ContainerSection.CRAFTING_IN,
                                         InvTweaksHandlerSorting.ALGORITHM_EVEN_STACKS,
                                         (containerMgr.getSize(target) == 9) ? 3 : 2).sort();
                             } catch (Exception e) {

--- a/src/minecraft/invtweaks/InvTweaks.java
+++ b/src/minecraft/invtweaks/InvTweaks.java
@@ -1,9 +1,5 @@
 package invtweaks;
 
-import invtweaks.InvTweaksConst;
-import invtweaks.InvTweaksItemTree;
-import invtweaks.InvTweaksItemTreeItem;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -14,6 +10,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import invtweaks.api.InvTweaksContainerSection;
 import net.minecraft.client.Minecraft;
 import net.minecraft.src.GuiButton;
 import net.minecraft.src.GuiContainer;

--- a/src/minecraft/invtweaks/InvTweaksContainerManager.java
+++ b/src/minecraft/invtweaks/InvTweaksContainerManager.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
-import invtweaks.api.InvTweaksContainerSection;
+import invtweaks.api.ContainerSection;
 import org.lwjgl.input.Mouse;
 
 import net.minecraft.client.Minecraft;
@@ -35,8 +35,8 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
 
     private GuiContainer guiContainer;
     private Container container;
-    private Map<InvTweaksContainerSection, List<Slot>> slotRefs
-            = new HashMap<InvTweaksContainerSection, List<Slot>>();
+    private Map<ContainerSection, List<Slot>> slotRefs
+            = new HashMap<ContainerSection, List<Slot>>();
     private int clickDelay = 0;
 
 
@@ -65,45 +65,45 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
 
         // Inventory: 4 crafting slots, then 4 armor slots, then inventory
         if (isContainerPlayer(container)) {
-            slotRefs.put(InvTweaksContainerSection.CRAFTING_OUT, slots.subList(0, 1));
-            slotRefs.put(InvTweaksContainerSection.CRAFTING_IN, slots.subList(1, 5));
-            slotRefs.put(InvTweaksContainerSection.ARMOR, slots.subList(5, 9));
+            slotRefs.put(ContainerSection.CRAFTING_OUT, slots.subList(0, 1));
+            slotRefs.put(ContainerSection.CRAFTING_IN, slots.subList(1, 5));
+            slotRefs.put(ContainerSection.ARMOR, slots.subList(5, 9));
         }
 
         // Creative mode inventory: 4 armor slots, then inventory
         else if (isContainerCreative(container)) {
-            slotRefs.put(InvTweaksContainerSection.ARMOR, slots.subList(5, 9));
+            slotRefs.put(ContainerSection.ARMOR, slots.subList(5, 9));
             size--; // Last slot is something else than the inventory (maybe the trash)
         }
 
         // Chest/Dispenser
         else if (isContainerChest(container)
                 || isContainerDispenser(container)) {
-            slotRefs.put(InvTweaksContainerSection.CHEST, slots.subList(0, size-INVENTORY_SIZE));
+            slotRefs.put(ContainerSection.CHEST, slots.subList(0, size-INVENTORY_SIZE));
         }
 
         // Furnace
         else if (isContainerFurnace(container)) {
-            slotRefs.put(InvTweaksContainerSection.FURNACE_IN, slots.subList(0, 1));
-            slotRefs.put(InvTweaksContainerSection.FURNACE_FUEL, slots.subList(1, 2));
-            slotRefs.put(InvTweaksContainerSection.FURNACE_OUT, slots.subList(2, 3));
+            slotRefs.put(ContainerSection.FURNACE_IN, slots.subList(0, 1));
+            slotRefs.put(ContainerSection.FURNACE_FUEL, slots.subList(1, 2));
+            slotRefs.put(ContainerSection.FURNACE_OUT, slots.subList(2, 3));
         }
 
         // Workbench
         else if (isContainerWorkbench(container)) {
-            slotRefs.put(InvTweaksContainerSection.CRAFTING_OUT, slots.subList(0, 1));
-            slotRefs.put(InvTweaksContainerSection.CRAFTING_IN, slots.subList(1, 10));
+            slotRefs.put(ContainerSection.CRAFTING_OUT, slots.subList(0, 1));
+            slotRefs.put(ContainerSection.CRAFTING_IN, slots.subList(1, 10));
         }
 
         // Enchantment table
         else if (isContainerEnchantmentTable(container)) {
-            slotRefs.put(InvTweaksContainerSection.ENCHANTMENT, slots.subList(0, 1));
+            slotRefs.put(ContainerSection.ENCHANTMENT, slots.subList(0, 1));
         }
 
         // Brewing stand
         else if (isContainerBrewingStand(container)) {
-            slotRefs.put(InvTweaksContainerSection.BREWING_BOTTLES, slots.subList(0, 3));
-            slotRefs.put(InvTweaksContainerSection.BREWING_INGREDIENT, slots.subList(3, 4));
+            slotRefs.put(ContainerSection.BREWING_BOTTLES, slots.subList(0, 3));
+            slotRefs.put(ContainerSection.BREWING_INGREDIENT, slots.subList(3, 4));
         }
 
         // Unknown = chest
@@ -116,19 +116,19 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
         	if (slotRefs.isEmpty()) {
 	            if (size >= INVENTORY_SIZE) {
 	                // Assuming the container ends with the inventory, just like all vanilla containers.
-	                slotRefs.put(InvTweaksContainerSection.CHEST, slots.subList(0, size-INVENTORY_SIZE));
+	                slotRefs.put(ContainerSection.CHEST, slots.subList(0, size-INVENTORY_SIZE));
 	            }
 	            else {
 	                guiWithInventory = false;
-	                slotRefs.put(InvTweaksContainerSection.CHEST, slots.subList(0, size));
+	                slotRefs.put(ContainerSection.CHEST, slots.subList(0, size));
 	            }
         	}
         }
 
-        if (guiWithInventory && !slotRefs.containsKey(InvTweaksContainerSection.INVENTORY)) {
-            slotRefs.put(InvTweaksContainerSection.INVENTORY, slots.subList(size-INVENTORY_SIZE, size));
-            slotRefs.put(InvTweaksContainerSection.INVENTORY_NOT_HOTBAR, slots.subList(size-INVENTORY_SIZE, size-HOTBAR_SIZE));
-            slotRefs.put(InvTweaksContainerSection.INVENTORY_HOTBAR, slots.subList(size-HOTBAR_SIZE, size));
+        if (guiWithInventory && !slotRefs.containsKey(ContainerSection.INVENTORY)) {
+            slotRefs.put(ContainerSection.INVENTORY, slots.subList(size-INVENTORY_SIZE, size));
+            slotRefs.put(ContainerSection.INVENTORY_NOT_HOTBAR, slots.subList(size-INVENTORY_SIZE, size-HOTBAR_SIZE));
+            slotRefs.put(ContainerSection.INVENTORY_HOTBAR, slots.subList(size-HOTBAR_SIZE, size));
         }
 
     }
@@ -148,8 +148,8 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
      * holding an item that couln't be put down.
      * @throws TimeoutException
      */
-	public boolean move(InvTweaksContainerSection srcSection, int srcIndex,
-            InvTweaksContainerSection destSection, int destIndex) {
+	public boolean move(ContainerSection srcSection, int srcIndex,
+            ContainerSection destSection, int destIndex) {
 	    //System.out.println(srcSection + ":" + srcIndex + " to " + destSection + ":" + destIndex);
 	    ItemStack srcStack = getItemStack(srcSection, srcIndex);
 	    ItemStack destStack = getItemStack(destSection, destIndex);
@@ -163,9 +163,9 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
 
         // Put hold item down
         if (getHeldStack() != null) {
-            int firstEmptyIndex = getFirstEmptyIndex(InvTweaksContainerSection.INVENTORY);
+            int firstEmptyIndex = getFirstEmptyIndex(ContainerSection.INVENTORY);
             if (firstEmptyIndex != -1) {
-                leftClick(InvTweaksContainerSection.INVENTORY, firstEmptyIndex);
+                leftClick(ContainerSection.INVENTORY, firstEmptyIndex);
             }
             else {
                 return false;
@@ -179,7 +179,7 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
                     hasDataTags(srcStack) || hasDataTags(destStack)
                 )) {
             int intermediateSlot = getFirstEmptyUsableSlotNumber();
-            InvTweaksContainerSection intermediateSection = getSlotSection(intermediateSlot);
+            ContainerSection intermediateSection = getSlotSection(intermediateSlot);
             int intermediateIndex = getSlotIndex(intermediateSlot);
             if (intermediateIndex != -1) {
                 // Step 1/3: Dest > Int
@@ -223,8 +223,8 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
 	 * by a different item (meaning items cannot be moved to destination).
 	 * @throws TimeoutException
 	 */
-	public boolean moveSome(InvTweaksContainerSection srcSection, int srcIndex,
-	        InvTweaksContainerSection destSection, int destIndex,
+	public boolean moveSome(ContainerSection srcSection, int srcIndex,
+	        ContainerSection destSection, int destIndex,
 	        int amount) {
 
 	    ItemStack source = getItemStack(srcSection, srcIndex);
@@ -254,11 +254,11 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
 
 	}
 
-    public boolean drop(InvTweaksContainerSection srcSection, int srcIndex) {
+    public boolean drop(ContainerSection srcSection, int srcIndex) {
         return move(srcSection, srcIndex, null, DROP_SLOT);
     }
 
-    public boolean dropSome(InvTweaksContainerSection srcSection, int srcIndex, int amount) {
+    public boolean dropSome(ContainerSection srcSection, int srcIndex, int amount) {
         return moveSome(srcSection, srcIndex, null, DROP_SLOT, amount);
     }
 
@@ -268,7 +268,7 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
      * @return true unless the item could not be put down
      * @throws Exception
      */
-    public boolean putHoldItemDown(InvTweaksContainerSection destSection, int destIndex) {
+    public boolean putHoldItemDown(ContainerSection destSection, int destIndex) {
         ItemStack heldStack = getHeldStack();
         if (heldStack != null) {
         	if (getItemStack(destSection, destIndex) == null) {
@@ -280,16 +280,16 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
         return true;
     }
 
-	public void leftClick(InvTweaksContainerSection section, int index) {
+	public void leftClick(ContainerSection section, int index) {
         click(section, index, false);
     }
 
-    public void rightClick(InvTweaksContainerSection section, int index) {
+    public void rightClick(ContainerSection section, int index) {
         click(section, index, true);
     }
 
 
-    public void click(InvTweaksContainerSection section, int index, boolean rightClick) {
+    public void click(ContainerSection section, int index, boolean rightClick) {
         //System.out.println("Click " + section + ":" + index);
         // Click! (we finally call the Minecraft code)
         int slot = indexToSlot(section, index);
@@ -360,11 +360,11 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
     }
 
 
-	public boolean hasSection(InvTweaksContainerSection section) {
+	public boolean hasSection(ContainerSection section) {
         return slotRefs.containsKey(section);
     }
 
-    public List<Slot> getSlots(InvTweaksContainerSection section) {
+    public List<Slot> getSlots(ContainerSection section) {
         return slotRefs.get(section);
     }
 
@@ -384,7 +384,7 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
      * @param slot
      * @return The size, or 0 if there is no such section.
      */
-    public int getSize(InvTweaksContainerSection section) {
+    public int getSize(ContainerSection section) {
         if (hasSection(section)) {
             return slotRefs.get(section).size();
         }
@@ -398,7 +398,7 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
      * @param section
      * @return -1 if no slot is free
      */
-    public int getFirstEmptyIndex(InvTweaksContainerSection section) {
+    public int getFirstEmptyIndex(ContainerSection section) {
         int i = 0;
         for (Slot slot : slotRefs.get(section)) {
             if (!hasStack(slot)) {
@@ -413,7 +413,7 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
      * @param slot
      * @return true if the specified slot exists and is empty, false otherwise.
      */
-    public boolean isSlotEmpty(InvTweaksContainerSection section, int slot) {
+    public boolean isSlotEmpty(ContainerSection section, int slot) {
         if (hasSection(section)) {
             return getItemStack(section, slot) == null;
         }
@@ -422,7 +422,7 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
         }
     }
 
-    public Slot getSlot(InvTweaksContainerSection section, int index) {
+    public Slot getSlot(ContainerSection section, int index) {
         List<Slot> slots = slotRefs.get(section);
         if (slots != null) {
             return slots.get(index);
@@ -449,10 +449,10 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
      */
     public int getSlotIndex(int slotNumber, boolean preferInventory) {
         // TODO Caching with getSlotSection
-        for (InvTweaksContainerSection section : slotRefs.keySet()) {
-            if (!preferInventory && section != InvTweaksContainerSection.INVENTORY
-                    || (preferInventory && section != InvTweaksContainerSection.INVENTORY_NOT_HOTBAR
-                            && section != InvTweaksContainerSection.INVENTORY_HOTBAR)) {
+        for (ContainerSection section : slotRefs.keySet()) {
+            if (!preferInventory && section != ContainerSection.INVENTORY
+                    || (preferInventory && section != ContainerSection.INVENTORY_NOT_HOTBAR
+                            && section != ContainerSection.INVENTORY_HOTBAR)) {
                 int i = 0;
                 for (Slot slot : slotRefs.get(section)) {
                     if (getSlotNumber(slot) == slotNumber) {
@@ -470,10 +470,10 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
      * @param slotNumber
      * @return null if the slot number is invalid.
      */
-    public InvTweaksContainerSection getSlotSection(int slotNumber) {
+    public ContainerSection getSlotSection(int slotNumber) {
         // TODO Caching with getSlotIndex
-        for (InvTweaksContainerSection section : slotRefs.keySet()) {
-            if (section != InvTweaksContainerSection.INVENTORY) {
+        for (ContainerSection section : slotRefs.keySet()) {
+            if (section != ContainerSection.INVENTORY) {
                 for (Slot slot : slotRefs.get(section)) {
                     if (getSlotNumber(slot) == slotNumber) {
                         return section;
@@ -490,7 +490,7 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
      * @param slot
      * @return An ItemStack or null.
      */
-    public ItemStack getItemStack(InvTweaksContainerSection section, int index)
+    public ItemStack getItemStack(ContainerSection section, int index)
             throws NullPointerException, IndexOutOfBoundsException {
         int slot = indexToSlot(section, index);
         if (slot >= 0 && slot < getSlots(container).size()) {
@@ -505,7 +505,7 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
     }
 
     private int getFirstEmptyUsableSlotNumber() {
-        for (InvTweaksContainerSection section : slotRefs.keySet()) {
+        for (ContainerSection section : slotRefs.keySet()) {
             for (Slot slot : slotRefs.get(section)) {
                 // Use only standard slot (to make sure
                 // we can freely put and remove items there)
@@ -523,7 +523,7 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
      * @param index
      * @return -1 if not found
      */
-    private int indexToSlot(InvTweaksContainerSection section, int index) {
+    private int indexToSlot(ContainerSection section, int index) {
         if (index == DROP_SLOT) {
             return DROP_SLOT;
         }

--- a/src/minecraft/invtweaks/InvTweaksContainerSectionManager.java
+++ b/src/minecraft/invtweaks/InvTweaksContainerSectionManager.java
@@ -3,6 +3,7 @@ package invtweaks;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
+import invtweaks.api.InvTweaksContainerSection;
 import net.minecraft.client.Minecraft;
 import net.minecraft.src.Container;
 import net.minecraft.src.ItemStack;
@@ -11,7 +12,7 @@ import net.minecraft.src.Slot;
 /**
  * Allows to perform various operations on a single section of
  * the inventory and/or containers. Works in both single and multiplayer.
- * 
+ *
  * @author Jimeo Wan
  *
  */
@@ -19,15 +20,15 @@ public class InvTweaksContainerSectionManager {
 
     private InvTweaksContainerManager containerMgr;
     private InvTweaksContainerSection section;
-    
+
     public InvTweaksContainerSectionManager(Minecraft mc, InvTweaksContainerSection section) throws Exception {
         this(new InvTweaksContainerManager(mc), section);
     }
-    
+
     public void setClickDelay(int delay) {
         this.containerMgr.setClickDelay(delay);
     }
-    
+
     public InvTweaksContainerSectionManager(InvTweaksContainerManager manager, InvTweaksContainerSection section) throws Exception {
         this.containerMgr = manager;
         this.section = section;
@@ -47,15 +48,15 @@ public class InvTweaksContainerSectionManager {
     public boolean drop(int srcIndex) throws TimeoutException {
         return containerMgr.drop(section, srcIndex);
     }
-    
+
     public boolean dropSome(int srcIndex, int amount) throws TimeoutException {
         return containerMgr.dropSome(section, srcIndex, amount);
     }
-    
+
     public boolean putHoldItemDown(int destIndex) throws TimeoutException {
         return containerMgr.putHoldItemDown(section, destIndex);
     }
-    
+
     public void leftClick(int index) throws TimeoutException {
         containerMgr.leftClick(section, index);
     }
@@ -87,7 +88,7 @@ public class InvTweaksContainerSectionManager {
     public Slot getSlot(int index) {
         return containerMgr.getSlot(section, index);
     }
-    
+
     public int getSlotIndex(int slotNumber) {
         if (isSlotInSection(slotNumber)) {
             return containerMgr.getSlotIndex(slotNumber);
@@ -100,7 +101,7 @@ public class InvTweaksContainerSectionManager {
     public boolean isSlotInSection(int slotNumber) {
         return containerMgr.getSlotSection(slotNumber) == section;
     }
-    
+
     public ItemStack getItemStack(int index) throws NullPointerException, IndexOutOfBoundsException {
         return containerMgr.getItemStack(section, index);
     }
@@ -108,5 +109,5 @@ public class InvTweaksContainerSectionManager {
     public Container getContainer() {
         return containerMgr.getContainer();
     }
-    
+
 }

--- a/src/minecraft/invtweaks/InvTweaksContainerSectionManager.java
+++ b/src/minecraft/invtweaks/InvTweaksContainerSectionManager.java
@@ -3,7 +3,7 @@ package invtweaks;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
-import invtweaks.api.InvTweaksContainerSection;
+import invtweaks.api.ContainerSection;
 import net.minecraft.client.Minecraft;
 import net.minecraft.src.Container;
 import net.minecraft.src.ItemStack;
@@ -19,9 +19,9 @@ import net.minecraft.src.Slot;
 public class InvTweaksContainerSectionManager {
 
     private InvTweaksContainerManager containerMgr;
-    private InvTweaksContainerSection section;
+    private ContainerSection section;
 
-    public InvTweaksContainerSectionManager(Minecraft mc, InvTweaksContainerSection section) throws Exception {
+    public InvTweaksContainerSectionManager(Minecraft mc, ContainerSection section) throws Exception {
         this(new InvTweaksContainerManager(mc), section);
     }
 
@@ -29,7 +29,7 @@ public class InvTweaksContainerSectionManager {
         this.containerMgr.setClickDelay(delay);
     }
 
-    public InvTweaksContainerSectionManager(InvTweaksContainerManager manager, InvTweaksContainerSection section) throws Exception {
+    public InvTweaksContainerSectionManager(InvTweaksContainerManager manager, ContainerSection section) throws Exception {
         this.containerMgr = manager;
         this.section = section;
         if (!containerMgr.hasSection(section)) {

--- a/src/minecraft/invtweaks/InvTweaksGuiSettingsButton.java
+++ b/src/minecraft/invtweaks/InvTweaksGuiSettingsButton.java
@@ -3,7 +3,7 @@ package invtweaks;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 
-import invtweaks.api.InvTweaksContainerSection;
+import invtweaks.api.ContainerSection;
 import net.minecraft.client.Minecraft;
 import net.minecraft.src.InvTweaksObfuscation;
 
@@ -48,7 +48,7 @@ public class InvTweaksGuiSettingsButton extends InvTweaksGuiIconButton {
 
             try {
                 containerMgr = new InvTweaksContainerSectionManager(
-                        minecraft, InvTweaksContainerSection.INVENTORY);
+                        minecraft, ContainerSection.INVENTORY);
                 containerMgr.setClickDelay(config.getClickDelay());
                 if (obf.getHeldStack() != null) {
                     try {

--- a/src/minecraft/invtweaks/InvTweaksGuiSettingsButton.java
+++ b/src/minecraft/invtweaks/InvTweaksGuiSettingsButton.java
@@ -3,7 +3,7 @@ package invtweaks;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 
-
+import invtweaks.api.InvTweaksContainerSection;
 import net.minecraft.client.Minecraft;
 import net.minecraft.src.InvTweaksObfuscation;
 
@@ -38,14 +38,14 @@ public class InvTweaksGuiSettingsButton extends InvTweaksGuiIconButton {
      * Displays inventory settings GUI
      */
     public boolean mousePressed(Minecraft minecraft, int i, int j) {
-        
+
         InvTweaksObfuscation obf = new InvTweaksObfuscation(minecraft);
         InvTweaksConfig config = cfgManager.getConfig();
-        
+
         if (super.mousePressed(minecraft, i, j)) {
             // Put hold item down if necessary
             InvTweaksContainerSectionManager containerMgr;
-            
+
             try {
                 containerMgr = new InvTweaksContainerSectionManager(
                         minecraft, InvTweaksContainerSection.INVENTORY);
@@ -66,7 +66,7 @@ public class InvTweaksGuiSettingsButton extends InvTweaksGuiIconButton {
             } catch (Exception e) {
             	log.severe(e.getMessage());
             }
-            
+
             // Refresh config
             cfgManager.makeSureConfigurationIsLoaded();
 
@@ -78,5 +78,5 @@ public class InvTweaksGuiSettingsButton extends InvTweaksGuiIconButton {
             return false;
         }
     }
-    
+
 }

--- a/src/minecraft/invtweaks/InvTweaksGuiSortingButton.java
+++ b/src/minecraft/invtweaks/InvTweaksGuiSortingButton.java
@@ -1,6 +1,6 @@
 package invtweaks;
 
-import invtweaks.api.InvTweaksContainerSection;
+import invtweaks.api.ContainerSection;
 import net.minecraft.client.Minecraft;
 
 /**
@@ -10,7 +10,7 @@ import net.minecraft.client.Minecraft;
  */
 public class InvTweaksGuiSortingButton extends InvTweaksGuiIconButton {
 
-    private final InvTweaksContainerSection section = InvTweaksContainerSection.CHEST;
+    private final ContainerSection section = ContainerSection.CHEST;
 
     private int algorithm;
     private int rowSize;

--- a/src/minecraft/invtweaks/InvTweaksGuiSortingButton.java
+++ b/src/minecraft/invtweaks/InvTweaksGuiSortingButton.java
@@ -1,5 +1,6 @@
 package invtweaks;
 
+import invtweaks.api.InvTweaksContainerSection;
 import net.minecraft.client.Minecraft;
 
 /**
@@ -10,11 +11,11 @@ import net.minecraft.client.Minecraft;
 public class InvTweaksGuiSortingButton extends InvTweaksGuiIconButton {
 
     private final InvTweaksContainerSection section = InvTweaksContainerSection.CHEST;
-    
+
     private int algorithm;
     private int rowSize;
 
-    public InvTweaksGuiSortingButton(InvTweaksConfigManager cfgManager, 
+    public InvTweaksGuiSortingButton(InvTweaksConfigManager cfgManager,
             int id, int x, int y, int w, int h,
             String displayString, String tooltip,
             int algorithm, int rowSize, boolean useCustomTexture) {
@@ -25,7 +26,7 @@ public class InvTweaksGuiSortingButton extends InvTweaksGuiIconButton {
 
     public void drawButton(Minecraft minecraft, int i, int j) {
         super.drawButton(minecraft, i, j);
-        
+
         // Display symbol
         int textColor = getTextColor(i, j);
         if (getDisplayString().equals("h")) {
@@ -61,5 +62,5 @@ public class InvTweaksGuiSortingButton extends InvTweaksGuiIconButton {
         }
 
     }
-    
+
 }

--- a/src/minecraft/invtweaks/InvTweaksHandlerAutoRefill.java
+++ b/src/minecraft/invtweaks/InvTweaksHandlerAutoRefill.java
@@ -1,43 +1,39 @@
 package invtweaks;
 
-import invtweaks.InvTweaksConst;
-import invtweaks.InvTweaksItemTree;
-import invtweaks.InvTweaksItemTreeItem;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 
-
+import invtweaks.api.InvTweaksContainerSection;
 import net.minecraft.client.Minecraft;
 import net.minecraft.src.InvTweaksObfuscation;
 import net.minecraft.src.ItemStack;
 
 /**
  * Handles the auto-refilling of the hotbar.
- * 
+ *
  * @author Jimeo Wan
  *
  */
 public class InvTweaksHandlerAutoRefill extends InvTweaksObfuscation {
-    
+
     private static final Logger log = Logger.getLogger("InvTweaks");
 
     private InvTweaksConfig config = null;
-    
+
     public InvTweaksHandlerAutoRefill(Minecraft mc, InvTweaksConfig config) {
 		super(mc);
 		setConfig(config);
 	}
-    
+
     public void setConfig(InvTweaksConfig config) {
     	this.config = config;
     }
-    
+
 	/**
      * Auto-refill
-	 * @throws Exception 
+	 * @throws Exception
      */
 	public void autoRefillSlot(int slot, int wantedId, int wantedDamage) throws Exception {
 
@@ -47,19 +43,19 @@ public class InvTweaksHandlerAutoRefill extends InvTweaksObfuscation {
 		ItemStack candidateStack, replacementStack = null;
 		int replacementStackSlot = -1;
         boolean refillBeforeBreak = config.getProperty(InvTweaksConfig.PROP_AUTO_REFILL_BEFORE_BREAK)
-                .equals(InvTweaksConfig.VALUE_TRUE); 
-		
+                .equals(InvTweaksConfig.VALUE_TRUE);
+
 		List<InvTweaksConfigSortingRule> matchingRules = new ArrayList<InvTweaksConfigSortingRule>();
 		List<InvTweaksConfigSortingRule> rules = config.getRules();
 		InvTweaksItemTree tree = config.getTree();
-		
+
 		// Check that the item is in the tree
         if (!tree.isItemUnknown(wantedId, wantedDamage)) {
-            
+
             //// Search replacement
-            
+
     		List<InvTweaksItemTreeItem> items = tree.getItems(wantedId, wantedDamage);
-    
+
     		// Find rules that match the slot
     		for (InvTweaksItemTreeItem item : items) {
     			// Since we search a matching item using rules,
@@ -69,7 +65,7 @@ public class InvTweaksHandlerAutoRefill extends InvTweaksObfuscation {
     					InvTweaksConst.INVENTORY_SIZE, InvTweaksConst.INVENTORY_ROW_SIZE));
     		}
     		for (InvTweaksConfigSortingRule rule : rules) {
-    			if (rule.getType() == InvTweaksConfigSortingRuleType.SLOT 
+    			if (rule.getType() == InvTweaksConfigSortingRuleType.SLOT
     			        || rule.getType() == InvTweaksConfigSortingRuleType.COLUMN) {
     				for (int preferredSlot : rule.getPreferredSlots()) {
     					if (slot == preferredSlot) {
@@ -79,7 +75,7 @@ public class InvTweaksHandlerAutoRefill extends InvTweaksObfuscation {
     				}
     			}
     		}
-    
+
     		// Look only for a matching stack
     		// First, look for the same item,
     		// else one that matches the slot's rules
@@ -110,12 +106,12 @@ public class InvTweaksHandlerAutoRefill extends InvTweaksObfuscation {
     			}
     		}
         }
-        
+
         // If item is unknown, look for exact same item
         else {
             for (int i = 0; i < InvTweaksConst.INVENTORY_SIZE; i++) {
                 candidateStack = container.getItemStack(i);
-                if (candidateStack != null && 
+                if (candidateStack != null &&
                         getItemID(candidateStack) == wantedId &&
                         getItemDamage(candidateStack) == wantedDamage) {
                     replacementStack = candidateStack;
@@ -124,15 +120,15 @@ public class InvTweaksHandlerAutoRefill extends InvTweaksObfuscation {
                 }
             }
         }
-		
+
 		//// Proceed to replacement
-	
+
 		if (replacementStack != null || (refillBeforeBreak && getStack(container.getSlot(slot)) != null)) {
-			
+
 			log.info("Automatic stack replacement.");
-			
+
 		    /*
-		     * This allows to have a short feedback 
+		     * This allows to have a short feedback
 		     * that the stack/tool is empty/broken.
 		     */
 			new Thread(new Runnable() {
@@ -141,7 +137,7 @@ public class InvTweaksHandlerAutoRefill extends InvTweaksObfuscation {
 				private int targetedSlot;
 				private int i, expectedItemId;
 				private boolean refillBeforeBreak;
-				
+
 				public Runnable init(Minecraft mc,
 						int i, int currentItem, boolean refillBeforeBreak) throws Exception {
 					this.containerMgr = new InvTweaksContainerSectionManager(
@@ -158,9 +154,9 @@ public class InvTweaksHandlerAutoRefill extends InvTweaksObfuscation {
 					this.refillBeforeBreak = refillBeforeBreak;
 					return this;
 				}
-				
+
 				public void run() {
-					
+
 					// Wait for the server to confirm that the
 					// slot is now empty
 					int pollingTime = 0;
@@ -176,7 +172,7 @@ public class InvTweaksHandlerAutoRefill extends InvTweaksObfuscation {
 						trySleep(InvTweaksConst.AUTO_REFILL_DELAY - pollingTime);
 					if (pollingTime >= InvTweaksConst.POLLING_TIMEOUT)
 						log.warning("Autoreplace timout");
-					
+
 					// In POLLING_DELAY ms, things might have changed
 					try {
 						ItemStack stack = containerMgr.getItemStack(i);
@@ -202,19 +198,19 @@ public class InvTweaksHandlerAutoRefill extends InvTweaksObfuscation {
 						}
 					}
 					catch (NullPointerException e) {
-						// Nothing: Due to multithreading + 
+						// Nothing: Due to multithreading +
 						// unsafe accesses, NPE may (very rarely) occur (?).
 					} catch (TimeoutException e) {
 						log.severe("Failed to trigger autoreplace: "+e.getMessage());
 					}
-					
+
 				}
-				
+
 			}.init(mc, replacementStackSlot, slot, refillBeforeBreak)).start();
-			
+
 		}
     }
-	
+
 	private static void trySleep(int delay) {
 		try {
 			Thread.sleep(delay);

--- a/src/minecraft/invtweaks/InvTweaksHandlerAutoRefill.java
+++ b/src/minecraft/invtweaks/InvTweaksHandlerAutoRefill.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 
-import invtweaks.api.InvTweaksContainerSection;
+import invtweaks.api.ContainerSection;
 import net.minecraft.client.Minecraft;
 import net.minecraft.src.InvTweaksObfuscation;
 import net.minecraft.src.ItemStack;
@@ -38,7 +38,7 @@ public class InvTweaksHandlerAutoRefill extends InvTweaksObfuscation {
 	public void autoRefillSlot(int slot, int wantedId, int wantedDamage) throws Exception {
 
 		InvTweaksContainerSectionManager container = new InvTweaksContainerSectionManager(
-		        mc, InvTweaksContainerSection.INVENTORY);
+		        mc, ContainerSection.INVENTORY);
 		container.setClickDelay(config.getClickDelay());
 		ItemStack candidateStack, replacementStack = null;
 		int replacementStackSlot = -1;
@@ -141,7 +141,7 @@ public class InvTweaksHandlerAutoRefill extends InvTweaksObfuscation {
 				public Runnable init(Minecraft mc,
 						int i, int currentItem, boolean refillBeforeBreak) throws Exception {
 					this.containerMgr = new InvTweaksContainerSectionManager(
-					        mc, InvTweaksContainerSection.INVENTORY);
+					        mc, ContainerSection.INVENTORY);
 					this.targetedSlot = currentItem;
 					if (i != -1) {
 	                    this.i = i;

--- a/src/minecraft/invtweaks/InvTweaksHandlerShortcuts.java
+++ b/src/minecraft/invtweaks/InvTweaksHandlerShortcuts.java
@@ -8,7 +8,7 @@ import java.util.Vector;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 
-import invtweaks.api.InvTweaksContainerSection;
+import invtweaks.api.ContainerSection;
 import net.minecraft.client.Minecraft;
 import net.minecraft.src.InvTweaksObfuscation;
 import net.minecraft.src.ItemStack;
@@ -31,10 +31,10 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
 
 	private class ShortcutConfig {
         public InvTweaksShortcutType type = null;
-	    public InvTweaksContainerSection fromSection = null;
+	    public ContainerSection fromSection = null;
         public int fromIndex = -1;
         public ItemStack fromStack = null;
-        public InvTweaksContainerSection toSection = null;
+        public ContainerSection toSection = null;
         public int toIndex = -1;
         public boolean drop = false;
         public boolean forceEmptySlot = false;
@@ -180,7 +180,7 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
 
             // (Special case: can't move 1 item from crafting output)
             // TODO Better mod compat by testing slot class to make sure the 'move one' shortcut works
-            if (shortcutConfig.fromSection == InvTweaksContainerSection.CRAFTING_OUT
+            if (shortcutConfig.fromSection == ContainerSection.CRAFTING_OUT
                     && shortcutConfig.type == InvTweaksShortcutType.MOVE_ONE_ITEM) {
                 shortcutConfig.type = InvTweaksShortcutType.MOVE_ONE_STACK;
             }
@@ -189,7 +189,7 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
 
                 // Compute shortcut target
                 if (shortcutConfig.type == InvTweaksShortcutType.MOVE_TO_SPECIFIC_HOTBAR_SLOT) {
-                    shortcutConfig.toSection = InvTweaksContainerSection.INVENTORY_HOTBAR;
+                    shortcutConfig.toSection = ContainerSection.INVENTORY_HOTBAR;
                     InvTweaksShortcutMapping hotbarShortcut = isShortcutDown(InvTweaksShortcutType.MOVE_TO_SPECIFIC_HOTBAR_SLOT);
                     if (hotbarShortcut != null && !hotbarShortcut.getKeyCodes().isEmpty()) {
                          String keyName = Keyboard.getKeyName(hotbarShortcut.getKeyCodes().get(0));
@@ -198,36 +198,36 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
                 }
                 else {
                     // Compute targetable sections in order
-                    Vector<InvTweaksContainerSection> orderedSections = new Vector<InvTweaksContainerSection>();
+                    Vector<ContainerSection> orderedSections = new Vector<ContainerSection>();
 
                     // (Top part)
-                    if (container.hasSection(InvTweaksContainerSection.CHEST)) {
-                        orderedSections.add(InvTweaksContainerSection.CHEST);
+                    if (container.hasSection(ContainerSection.CHEST)) {
+                        orderedSections.add(ContainerSection.CHEST);
                     }
-                    else if (container.hasSection(InvTweaksContainerSection.CRAFTING_IN)) {
-                        orderedSections.add(InvTweaksContainerSection.CRAFTING_IN);
+                    else if (container.hasSection(ContainerSection.CRAFTING_IN)) {
+                        orderedSections.add(ContainerSection.CRAFTING_IN);
                     }
-                    else if (container.hasSection(InvTweaksContainerSection.FURNACE_IN)) {
-                        orderedSections.add(InvTweaksContainerSection.FURNACE_IN);
+                    else if (container.hasSection(ContainerSection.FURNACE_IN)) {
+                        orderedSections.add(ContainerSection.FURNACE_IN);
                     }
-                    else if (container.hasSection(InvTweaksContainerSection.BREWING_INGREDIENT)) {
+                    else if (container.hasSection(ContainerSection.BREWING_INGREDIENT)) {
                         ItemStack stack = container.getStack(slot);
                         if (stack != null) {
                             if (getItemID(stack) == 373 /* Water Bottle/Potions */) {
-                                orderedSections.add(InvTweaksContainerSection.BREWING_BOTTLES);
+                                orderedSections.add(ContainerSection.BREWING_BOTTLES);
                             }
                             else {
-                                orderedSections.add(InvTweaksContainerSection.BREWING_INGREDIENT);
+                                orderedSections.add(ContainerSection.BREWING_INGREDIENT);
                             }
                         }
                     }
-                    else if (container.hasSection(InvTweaksContainerSection.ENCHANTMENT)) {
-                        orderedSections.add(InvTweaksContainerSection.ENCHANTMENT);
+                    else if (container.hasSection(ContainerSection.ENCHANTMENT)) {
+                        orderedSections.add(ContainerSection.ENCHANTMENT);
                     }
 
                     // (Inventory part)
-                    orderedSections.add(InvTweaksContainerSection.INVENTORY_NOT_HOTBAR);
-                    orderedSections.add(InvTweaksContainerSection.INVENTORY_HOTBAR);
+                    orderedSections.add(ContainerSection.INVENTORY_NOT_HOTBAR);
+                    orderedSections.add(ContainerSection.INVENTORY_HOTBAR);
 
                     // Choose target section
                     boolean upMapping = isShortcutDown(InvTweaksShortcutType.MOVE_UP) != null,
@@ -246,28 +246,28 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
                                     (orderedSections.size() + fromSectionIndex + sectionOffset) % orderedSections.size());
                         }
                         else {
-                            shortcutConfig.toSection = InvTweaksContainerSection.INVENTORY;
+                            shortcutConfig.toSection = ContainerSection.INVENTORY;
                         }
                     }
                     else { // Implicit section
                         switch (shortcutConfig.fromSection) {
                         case CHEST:
-                            shortcutConfig.toSection = InvTweaksContainerSection.INVENTORY; break;
+                            shortcutConfig.toSection = ContainerSection.INVENTORY; break;
                         case INVENTORY_HOTBAR:
-                            if (orderedSections.contains(InvTweaksContainerSection.CHEST)) {
-                                shortcutConfig.toSection = InvTweaksContainerSection.CHEST;
+                            if (orderedSections.contains(ContainerSection.CHEST)) {
+                                shortcutConfig.toSection = ContainerSection.CHEST;
                             } else {
-                                shortcutConfig.toSection = InvTweaksContainerSection.INVENTORY_NOT_HOTBAR;
+                                shortcutConfig.toSection = ContainerSection.INVENTORY_NOT_HOTBAR;
                             }
                             break;
                         case CRAFTING_IN:
                         case FURNACE_IN:
-                            shortcutConfig.toSection = InvTweaksContainerSection.INVENTORY_NOT_HOTBAR; break;
+                            shortcutConfig.toSection = ContainerSection.INVENTORY_NOT_HOTBAR; break;
                         default:
-                            if (orderedSections.contains(InvTweaksContainerSection.CHEST)) {
-                                shortcutConfig.toSection = InvTweaksContainerSection.CHEST;
+                            if (orderedSections.contains(ContainerSection.CHEST)) {
+                                shortcutConfig.toSection = ContainerSection.CHEST;
                             } else {
-                                shortcutConfig.toSection = InvTweaksContainerSection.INVENTORY_HOTBAR;
+                                shortcutConfig.toSection = ContainerSection.INVENTORY_HOTBAR;
                             }
                         }
                     }
@@ -343,8 +343,8 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
                     case MOVE_ONE_STACK:
                     {
                         Slot slot = container.getSlot(shortcut.fromSection, shortcut.fromIndex);
-                        if (shortcut.fromSection != InvTweaksContainerSection.CRAFTING_OUT
-                                && shortcut.toSection != InvTweaksContainerSection.ENCHANTMENT) {
+                        if (shortcut.fromSection != ContainerSection.CRAFTING_OUT
+                                && shortcut.toSection != ContainerSection.ENCHANTMENT) {
                             while (hasStack(slot) && toIndex != -1) {
                                 success = container.move(shortcut.fromSection, shortcut.fromIndex, shortcut.toSection, toIndex);
                                 newIndex = getNextTargetIndex(shortcut);
@@ -368,9 +368,9 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
                     case MOVE_ALL_ITEMS:
                     {
                         moveAll(shortcut, shortcut.fromStack);
-                        if (shortcut.fromSection == InvTweaksContainerSection.INVENTORY_NOT_HOTBAR
-                                && shortcut.toSection == InvTweaksContainerSection.CHEST) {
-                            shortcut.fromSection = InvTweaksContainerSection.INVENTORY_HOTBAR;
+                        if (shortcut.fromSection == ContainerSection.INVENTORY_NOT_HOTBAR
+                                && shortcut.toSection == ContainerSection.CHEST) {
+                            shortcut.fromSection = ContainerSection.INVENTORY_HOTBAR;
                             moveAll(shortcut, shortcut.fromStack);
                         }
                         break;
@@ -379,9 +379,9 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
                     case MOVE_EVERYTHING:
                     {
                         moveAll(shortcut, null);
-                        if (shortcut.fromSection == InvTweaksContainerSection.INVENTORY_HOTBAR
-                                && shortcut.toSection == InvTweaksContainerSection.CHEST) {
-                            shortcut.fromSection = InvTweaksContainerSection.INVENTORY_HOTBAR;
+                        if (shortcut.fromSection == ContainerSection.INVENTORY_HOTBAR
+                                && shortcut.toSection == ContainerSection.CHEST) {
+                            shortcut.fromSection = ContainerSection.INVENTORY_HOTBAR;
                             moveAll(shortcut, null);
                         }
                         break;
@@ -445,8 +445,8 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
 
         // Switch from FURNACE_IN to FURNACE_FUEL if the slot is taken
         // TODO Better furnace shortcuts
-        if (result == -1 && shortcut.toSection == InvTweaksContainerSection.FURNACE_IN) {
-            shortcut.toSection = InvTweaksContainerSection.FURNACE_FUEL;
+        if (result == -1 && shortcut.toSection == ContainerSection.FURNACE_IN) {
+            shortcut.toSection = ContainerSection.FURNACE_FUEL;
             result = container.getFirstEmptyIndex(shortcut.toSection);
         }
 

--- a/src/minecraft/invtweaks/InvTweaksHandlerShortcuts.java
+++ b/src/minecraft/invtweaks/InvTweaksHandlerShortcuts.java
@@ -8,6 +8,7 @@ import java.util.Vector;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 
+import invtweaks.api.InvTweaksContainerSection;
 import net.minecraft.client.Minecraft;
 import net.minecraft.src.InvTweaksObfuscation;
 import net.minecraft.src.ItemStack;
@@ -18,16 +19,16 @@ import org.lwjgl.input.Mouse;
 
 
 /**
- * 
+ *
  * @author Jimeo Wan
  *
  */
 public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
-    
+
     private static final Logger log = Logger.getLogger("InvTweaks");
 
     private static final int DROP_SLOT = -999;
-    
+
 	private class ShortcutConfig {
         public InvTweaksShortcutType type = null;
 	    public InvTweaksContainerSection fromSection = null;
@@ -38,9 +39,9 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
         public boolean drop = false;
         public boolean forceEmptySlot = false;
 	}
-	
+
 	private InvTweaksConfig config;
-	
+
     private InvTweaksContainerManager container;
 
     /**
@@ -53,7 +54,7 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
      */
     private Map<InvTweaksShortcutType, List<InvTweaksShortcutMapping>> shortcuts;
 
-    
+
     public InvTweaksHandlerShortcuts(Minecraft mc, InvTweaksConfig config) {
 		super(mc);
 		this.config = config;
@@ -64,7 +65,7 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
 	public void loadShortcuts() {
 		pressedKeys.clear();
 		shortcuts.clear();
-		
+
         // Register shortcut mappings
         Map<String, String> keys = config.getProperties(
                 InvTweaksConfig.PROP_SHORTCUT_PREFIX);
@@ -78,25 +79,25 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
                 }
             }
         }
-        
+
         // Add Minecraft's Up & Down mappings
         int upKeyCode = getKeyBindingForwardKeyCode(),
             downKeyCode = getKeyBindingBackKeyCode();
-        
+
         registerShortcutMapping(InvTweaksShortcutType.MOVE_UP, new InvTweaksShortcutMapping(upKeyCode));
         registerShortcutMapping(InvTweaksShortcutType.MOVE_DOWN, new InvTweaksShortcutMapping(downKeyCode));
 
         // Add hotbar shortcuts (1-9) mappings
-        int[] hotbarKeys = {Keyboard.KEY_1, Keyboard.KEY_2, Keyboard.KEY_3, 
+        int[] hotbarKeys = {Keyboard.KEY_1, Keyboard.KEY_2, Keyboard.KEY_3,
                 Keyboard.KEY_4, Keyboard.KEY_5, Keyboard.KEY_6,
                 Keyboard.KEY_7, Keyboard.KEY_8, Keyboard.KEY_9,
                 Keyboard.KEY_NUMPAD1, Keyboard.KEY_NUMPAD2, Keyboard.KEY_NUMPAD3,
-                Keyboard.KEY_NUMPAD4, Keyboard.KEY_NUMPAD5, Keyboard.KEY_NUMPAD6, 
+                Keyboard.KEY_NUMPAD4, Keyboard.KEY_NUMPAD5, Keyboard.KEY_NUMPAD6,
                 Keyboard.KEY_NUMPAD7, Keyboard.KEY_NUMPAD8, Keyboard.KEY_NUMPAD9};
         for (int i : hotbarKeys) {
             registerShortcutMapping(InvTweaksShortcutType.MOVE_TO_SPECIFIC_HOTBAR_SLOT, new InvTweaksShortcutMapping(i));
         }
-        
+
         // Register (L/R)SHIFT to allow to filter them
         pressedKeys.put(Keyboard.KEY_LSHIFT, false);
         pressedKeys.put(Keyboard.KEY_RSHIFT, false);
@@ -124,7 +125,7 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
     		ShortcutConfig shortcutToTrigger = computeShortcutToTrigger();
     		if (shortcutToTrigger != null) {
     	        int ex = Mouse.getEventX(), ey = Mouse.getEventY();
-    	        
+
                 // GO!
                 runShortcut(shortcutToTrigger);
 
@@ -132,12 +133,12 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
                 // TODO Find a better solution, like 'anticipate' default action?
                 Mouse.destroy();
                 Mouse.create();
-    
+
                 // Fixes a tiny glitch (Steve looks for a short moment
                 // at [0, 0] because of the mouse reset).
                 Mouse.setCursorPosition(ex, ey);
     		}
-    		
+
 		} catch (Exception e) {
             InvTweaks.logInGameErrorStatic("invtweaks.shortcut.error", e);
         }
@@ -145,22 +146,22 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
 
     public ShortcutConfig computeShortcutToTrigger() {
         updatePressedKeys();
-    
+
         // Init
         container = new InvTweaksContainerManager(mc);
         container.setClickDelay(config.getClickDelay());
         Slot slot = container.getSlotAtMousePosition();
         ShortcutConfig shortcutConfig = new ShortcutConfig();
-        
+
         // If a valid and not empty slot is clicked
         if (slot != null && (hasStack(slot) || getHeldStack() != null)) {
             int slotNumber = getSlotNumber(slot);
-            
+
             // Set shortcut origin
-            shortcutConfig.fromSection = container.getSlotSection(slotNumber);                
-            shortcutConfig.fromIndex = container.getSlotIndex(slotNumber);             
+            shortcutConfig.fromSection = container.getSlotSection(slotNumber);
+            shortcutConfig.fromIndex = container.getSlotIndex(slotNumber);
             shortcutConfig.fromStack = (hasStack(slot)) ? copy(getStack(slot)) : copy(getHeldStack());
-            
+
             // Compute shortcut type
             if (isShortcutDown(InvTweaksShortcutType.MOVE_TO_SPECIFIC_HOTBAR_SLOT) != null) {
                 shortcutConfig.type = InvTweaksShortcutType.MOVE_TO_SPECIFIC_HOTBAR_SLOT;
@@ -176,16 +177,16 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
                         || isShortcutDown(InvTweaksShortcutType.DROP) != null)) {
                 shortcutConfig.type = InvTweaksShortcutType.MOVE_ONE_STACK;
             }
-            
+
             // (Special case: can't move 1 item from crafting output)
             // TODO Better mod compat by testing slot class to make sure the 'move one' shortcut works
             if (shortcutConfig.fromSection == InvTweaksContainerSection.CRAFTING_OUT
                     && shortcutConfig.type == InvTweaksShortcutType.MOVE_ONE_ITEM) {
                 shortcutConfig.type = InvTweaksShortcutType.MOVE_ONE_STACK;
             }
-            
+
             if (shortcutConfig.fromSection != null && shortcutConfig.fromIndex != -1 && shortcutConfig.type != null) {
-            
+
                 // Compute shortcut target
                 if (shortcutConfig.type == InvTweaksShortcutType.MOVE_TO_SPECIFIC_HOTBAR_SLOT) {
                     shortcutConfig.toSection = InvTweaksContainerSection.INVENTORY_HOTBAR;
@@ -198,7 +199,7 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
                 else {
                     // Compute targetable sections in order
                     Vector<InvTweaksContainerSection> orderedSections = new Vector<InvTweaksContainerSection>();
-                    
+
                     // (Top part)
                     if (container.hasSection(InvTweaksContainerSection.CHEST)) {
                         orderedSections.add(InvTweaksContainerSection.CHEST);
@@ -223,11 +224,11 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
                     else if (container.hasSection(InvTweaksContainerSection.ENCHANTMENT)) {
                         orderedSections.add(InvTweaksContainerSection.ENCHANTMENT);
                     }
-                    
+
                     // (Inventory part)
                     orderedSections.add(InvTweaksContainerSection.INVENTORY_NOT_HOTBAR);
                     orderedSections.add(InvTweaksContainerSection.INVENTORY_HOTBAR);
-                    
+
                     // Choose target section
                     boolean upMapping = isShortcutDown(InvTweaksShortcutType.MOVE_UP) != null,
                             downMapping = isShortcutDown(InvTweaksShortcutType.MOVE_DOWN) != null;
@@ -271,16 +272,16 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
                         }
                     }
                 }
-                
+
                 // Shortcut modifiers
                 shortcutConfig.forceEmptySlot = Mouse.isButtonDown(1);
                 shortcutConfig.drop = isShortcutDown(InvTweaksShortcutType.DROP) != null;
-                
+
                 return shortcutConfig;
-            
+
             }
         }
-        
+
         return null;
     }
 
@@ -325,20 +326,20 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
                 return;
             }
         }
-        
+
         synchronized(this) {
             if (shortcut.type == InvTweaksShortcutType.MOVE_TO_SPECIFIC_HOTBAR_SLOT) {
                 container.move(shortcut.fromSection, shortcut.fromIndex, shortcut.toSection, shortcut.toIndex);
             }
             else {
-                
+
                 int toIndex = getNextTargetIndex(shortcut);
                 boolean success;
                 int newIndex;
-                
+
                 if (toIndex != -1) {
                     switch (shortcut.type) {
-                    
+
                     case MOVE_ONE_STACK:
                     {
                         Slot slot = container.getSlot(shortcut.fromSection, shortcut.fromIndex);
@@ -355,15 +356,15 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
                             container.move(shortcut.fromSection, shortcut.fromIndex, shortcut.toSection, toIndex);
                         }
                         break;
-        
+
                     }
-                    
+
                     case MOVE_ONE_ITEM:
                     {
                         container.moveSome(shortcut.fromSection, shortcut.fromIndex, shortcut.toSection, toIndex, 1);
                         break;
                     }
-                        
+
                     case MOVE_ALL_ITEMS:
                     {
                         moveAll(shortcut, shortcut.fromStack);
@@ -374,7 +375,7 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
                         }
                         break;
                     }
-                    
+
                     case MOVE_EVERYTHING:
                     {
                         moveAll(shortcut, null);
@@ -385,14 +386,14 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
                         }
                         break;
                     }
-                    
+
                     default:
-                        
+
                     }
                 }
-            
+
             }
-            
+
         }
     }
 
@@ -414,11 +415,11 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
         }
     }
     private int getNextTargetIndex(ShortcutConfig shortcut) {
-        
+
         if (shortcut.drop) {
             return DROP_SLOT;
         }
-        
+
         int result = -1;
 
         // Try to merge with existing slot
@@ -436,19 +437,19 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
                 i++;
             }
         }
-        
+
         // Else find empty slot
         if (result == -1) {
             result = container.getFirstEmptyIndex(shortcut.toSection);
         }
-        
+
         // Switch from FURNACE_IN to FURNACE_FUEL if the slot is taken
         // TODO Better furnace shortcuts
         if (result == -1 && shortcut.toSection == InvTweaksContainerSection.FURNACE_IN) {
             shortcut.toSection = InvTweaksContainerSection.FURNACE_FUEL;
             result = container.getFirstEmptyIndex(shortcut.toSection);
         }
-        
+
         return result;
     }
     /**

--- a/src/minecraft/invtweaks/InvTweaksHandlerSorting.java
+++ b/src/minecraft/invtweaks/InvTweaksHandlerSorting.java
@@ -13,7 +13,7 @@ import java.util.Vector;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 
-import invtweaks.api.InvTweaksContainerSection;
+import invtweaks.api.ContainerSection;
 import net.minecraft.client.Minecraft;
 import net.minecraft.src.InvTweaksObfuscation;
 import net.minecraft.src.Item;
@@ -59,7 +59,7 @@ public class InvTweaksHandlerSorting extends InvTweaksObfuscation {
     private boolean[] frozenSlots;
 
     public InvTweaksHandlerSorting(Minecraft mc, InvTweaksConfig config,
-            InvTweaksContainerSection section, int algorithm, int rowSize) throws Exception {
+            ContainerSection section, int algorithm, int rowSize) throws Exception {
         super(mc);
 
         // Init constants
@@ -88,7 +88,7 @@ public class InvTweaksHandlerSorting extends InvTweaksObfuscation {
 
         this.rules = config.getRules();
         this.tree = config.getTree();
-        if (section == InvTweaksContainerSection.INVENTORY) {
+        if (section == ContainerSection.INVENTORY) {
             this.lockPriorities = config.getLockPriorities();
             this.frozenSlots = config.getFrozenSlots();
             this.algorithm = ALGORITHM_INVENTORY;
@@ -127,9 +127,9 @@ public class InvTweaksHandlerSorting extends InvTweaksObfuscation {
 
         // Put hold item down
         if (getHeldStack() != null) {
-            int emptySlot = globalContainer.getFirstEmptyIndex(InvTweaksContainerSection.INVENTORY);
+            int emptySlot = globalContainer.getFirstEmptyIndex(ContainerSection.INVENTORY);
             if (emptySlot != -1) {
-                globalContainer.putHoldItemDown(InvTweaksContainerSection.INVENTORY, emptySlot);
+                globalContainer.putHoldItemDown(ContainerSection.INVENTORY, emptySlot);
             }
             else {
                 return; // Not enough room to work, abort
@@ -215,18 +215,18 @@ public class InvTweaksHandlerSorting extends InvTweaksObfuscation {
             } else if (algorithm == ALGORITHM_INVENTORY) {
                 //// Move items out of the crafting slots
                 log.info("Handling crafting slots.");
-                if (globalContainer.hasSection(InvTweaksContainerSection.CRAFTING_IN)) {
-                    List<Slot> craftingSlots = globalContainer.getSlots(InvTweaksContainerSection.CRAFTING_IN);
-                    int emptyIndex = globalContainer.getFirstEmptyIndex(InvTweaksContainerSection.INVENTORY);
+                if (globalContainer.hasSection(ContainerSection.CRAFTING_IN)) {
+                    List<Slot> craftingSlots = globalContainer.getSlots(ContainerSection.CRAFTING_IN);
+                    int emptyIndex = globalContainer.getFirstEmptyIndex(ContainerSection.INVENTORY);
                     if (emptyIndex != -1) {
                         for (Slot craftingSlot : craftingSlots) {
                             if (hasStack(craftingSlot)) {
                                 globalContainer.move(
-                                        InvTweaksContainerSection.CRAFTING_IN,
+                                        ContainerSection.CRAFTING_IN,
                                         globalContainer.getSlotIndex(getSlotNumber(craftingSlot)),
-                                        InvTweaksContainerSection.INVENTORY,
+                                        ContainerSection.INVENTORY,
                                         emptyIndex);
-                                emptyIndex = globalContainer.getFirstEmptyIndex(InvTweaksContainerSection.INVENTORY);
+                                emptyIndex = globalContainer.getFirstEmptyIndex(ContainerSection.INVENTORY);
                                 if(emptyIndex == -1) {
                                     break;
                                 }
@@ -250,8 +250,8 @@ public class InvTweaksHandlerSorting extends InvTweaksObfuscation {
 	                        if (sortArmorParts) {
 	                             if (isItemArmor(fromItem)) {
 	                            	 ItemArmor fromItemArmor = asItemArmor(fromItem);
-	                                 if (globalContainer.hasSection(InvTweaksContainerSection.ARMOR)) {
-	                                     List<Slot> armorSlots = globalContainer.getSlots(InvTweaksContainerSection.ARMOR);
+	                                 if (globalContainer.hasSection(ContainerSection.ARMOR)) {
+	                                     List<Slot> armorSlots = globalContainer.getSlots(ContainerSection.ARMOR);
 	                                     for (Slot slot : armorSlots) {
 	                                    	boolean move = false;
 	                                    	if (!hasStack(slot)) {
@@ -271,7 +271,7 @@ public class InvTweaksHandlerSorting extends InvTweaksObfuscation {
                                                 }
 	                                    	}
 	                                        if (areSlotAndStackCompatible(slot, from) && move) {
-	                                            globalContainer.move(InvTweaksContainerSection.INVENTORY, i, InvTweaksContainerSection.ARMOR,
+	                                            globalContainer.move(ContainerSection.INVENTORY, i, ContainerSection.ARMOR,
 	                                                    globalContainer.getSlotIndex(getSlotNumber(slot)));
 	                                        }
 	                                    }
@@ -376,9 +376,9 @@ public class InvTweaksHandlerSorting extends InvTweaksObfuscation {
 
         //// Put hold item down, just in case
         if (getHeldStack() != null) {
-            int emptySlot = globalContainer.getFirstEmptyIndex(InvTweaksContainerSection.INVENTORY);
+            int emptySlot = globalContainer.getFirstEmptyIndex(ContainerSection.INVENTORY);
             if (emptySlot != -1) {
-                globalContainer.putHoldItemDown(InvTweaksContainerSection.INVENTORY, emptySlot);
+                globalContainer.putHoldItemDown(ContainerSection.INVENTORY, emptySlot);
             }
         }
     }

--- a/src/minecraft/invtweaks/InvTweaksHandlerSorting.java
+++ b/src/minecraft/invtweaks/InvTweaksHandlerSorting.java
@@ -1,9 +1,5 @@
 package invtweaks;
 
-import invtweaks.InvTweaksConst;
-import invtweaks.InvTweaksItemTree;
-import invtweaks.InvTweaksItemTreeItem;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -17,7 +13,7 @@ import java.util.Vector;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 
-
+import invtweaks.api.InvTweaksContainerSection;
 import net.minecraft.client.Minecraft;
 import net.minecraft.src.InvTweaksObfuscation;
 import net.minecraft.src.Item;

--- a/src/minecraft/invtweaks/InvTweaksModCompatibility.java
+++ b/src/minecraft/invtweaks/InvTweaksModCompatibility.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import invtweaks.api.InvTweaksContainerSection;
+import invtweaks.api.ContainerSection;
 import net.minecraft.src.Container;
 import net.minecraft.src.GuiContainer;
 import net.minecraft.src.GuiScreen;
@@ -122,21 +122,21 @@ public class InvTweaksModCompatibility {
     }
 
 	@SuppressWarnings("unchecked")
-    public Map<InvTweaksContainerSection, List<Slot>> getSpecialContainerSlots(GuiScreen guiScreen, Container container) {
+    public Map<ContainerSection, List<Slot>> getSpecialContainerSlots(GuiScreen guiScreen, Container container) {
 
-    	Map<InvTweaksContainerSection, List<Slot>> result = new HashMap<InvTweaksContainerSection, List<Slot>>();
+    	Map<ContainerSection, List<Slot>> result = new HashMap<ContainerSection, List<Slot>>();
 		List<Slot> slots = (List<Slot>) obf.getSlots(container);
 
     	if (is(guiScreen, "GuiCondenser")) { // EE
-    		result.put(InvTweaksContainerSection.CHEST, slots.subList(1, slots.size() - 36));
+    		result.put(ContainerSection.CHEST, slots.subList(1, slots.size() - 36));
     	}
     	else if (is(guiScreen, "GuiAdvBench")) { // RedPower 2
-            result.put(InvTweaksContainerSection.CRAFTING_IN, slots.subList(0, 9));
-            result.put(InvTweaksContainerSection.CRAFTING_OUT, slots.subList(10, 11));
-            result.put(InvTweaksContainerSection.CHEST, slots.subList(11, 29));
+            result.put(ContainerSection.CRAFTING_IN, slots.subList(0, 9));
+            result.put(ContainerSection.CRAFTING_OUT, slots.subList(10, 11));
+            result.put(ContainerSection.CHEST, slots.subList(11, 29));
     	} else if(is(guiScreen, "GuiArcaneWorkbench") || is(guiScreen, "GuiInfusionWorkbench")) { // Thaumcraft 3
-            result.put(InvTweaksContainerSection.CRAFTING_OUT, slots.subList(0, 1));
-            result.put(InvTweaksContainerSection.CRAFTING_IN, slots.subList(2, 11));
+            result.put(ContainerSection.CRAFTING_OUT, slots.subList(0, 1));
+            result.put(ContainerSection.CRAFTING_IN, slots.subList(2, 11));
     	}
 
 		return result;

--- a/src/minecraft/invtweaks/InvTweaksModCompatibility.java
+++ b/src/minecraft/invtweaks/InvTweaksModCompatibility.java
@@ -1,11 +1,10 @@
 package invtweaks;
 
-import invtweaks.InvTweaksConst;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import invtweaks.api.InvTweaksContainerSection;
 import net.minecraft.src.Container;
 import net.minecraft.src.GuiContainer;
 import net.minecraft.src.GuiScreen;
@@ -14,13 +13,13 @@ import net.minecraft.src.Slot;
 
 
 public class InvTweaksModCompatibility {
-	
+
     private InvTweaksObfuscation obf;
-    
+
     public InvTweaksModCompatibility(InvTweaksObfuscation obf) {
     	this.obf = obf;
     }
-    
+
     /**
      * Returns true if the screen is a chest/dispenser,
      * despite not being a GuiChest or a GuiDispenser.
@@ -35,8 +34,8 @@ public class InvTweaksModCompatibility {
                 || is(guiScreen, "GuiGoldSafe") // More Storage
                 || is(guiScreen, "GuiLocker")
                 || is(guiScreen, "GuiDualLocker")
-                || is(guiScreen, "GuiSafe") 
-                || is(guiScreen, "GuiCabinet") 
+                || is(guiScreen, "GuiSafe")
+                || is(guiScreen, "GuiCabinet")
                 || is(guiScreen, "GuiTower")
                 || is(guiScreen, "GuiBufferChest") // Red Power 2
                 || is(guiScreen, "GuiRetriever") // Red Power 2
@@ -107,7 +106,7 @@ public class InvTweaksModCompatibility {
         		|| is(guiScreen, "FC_GuiChest") // Metallurgy
         	;
     }
-    
+
     /**
      * Returns true if the screen is the inventory screen, despite not being a GuiInventory.
      * @param guiScreen
@@ -124,10 +123,10 @@ public class InvTweaksModCompatibility {
 
 	@SuppressWarnings("unchecked")
     public Map<InvTweaksContainerSection, List<Slot>> getSpecialContainerSlots(GuiScreen guiScreen, Container container) {
-    	
+
     	Map<InvTweaksContainerSection, List<Slot>> result = new HashMap<InvTweaksContainerSection, List<Slot>>();
 		List<Slot> slots = (List<Slot>) obf.getSlots(container);
-    	
+
     	if (is(guiScreen, "GuiCondenser")) { // EE
     		result.put(InvTweaksContainerSection.CHEST, slots.subList(1, slots.size() - 36));
     	}
@@ -139,9 +138,9 @@ public class InvTweaksModCompatibility {
             result.put(InvTweaksContainerSection.CRAFTING_OUT, slots.subList(0, 1));
             result.put(InvTweaksContainerSection.CRAFTING_IN, slots.subList(2, 11));
     	}
-    	
+
 		return result;
-		
+
 	}
 
 	private static final boolean is(GuiScreen guiScreen, String className) {

--- a/src/minecraft/invtweaks/api/ContainerGUI.java
+++ b/src/minecraft/invtweaks/api/ContainerGUI.java
@@ -1,0 +1,25 @@
+package invtweaks.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ContainerGUI {
+    // Size of a chest row
+    int rowSize() default 9;
+
+    // Annotation for method to get special inventory slots
+    // Signature int func()
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface RowSizeCallback {}
+
+    // Annotation for method to get special inventory slots
+    // Signature Map<ContainerSection, List<Slot>> func()
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface ContainerSectionCallback {}
+}

--- a/src/minecraft/invtweaks/api/ContainerSection.java
+++ b/src/minecraft/invtweaks/api/ContainerSection.java
@@ -5,7 +5,7 @@ package invtweaks.api;
  * For unknown container types (such as mod containers),
  * only INVENTORY and CHEST sections are available.
  */
-public enum InvTweaksContainerSection {
+public enum ContainerSection {
     /** The player's inventory */
     INVENTORY,
     /** The player's inventory (only the hotbar) */

--- a/src/minecraft/invtweaks/api/InvTweaksContainerSection.java
+++ b/src/minecraft/invtweaks/api/InvTweaksContainerSection.java
@@ -1,4 +1,4 @@
-package invtweaks;
+package invtweaks.api;
 
 /**
  * Names for specific parts of containers.

--- a/src/minecraft/invtweaks/api/InventoryGUI.java
+++ b/src/minecraft/invtweaks/api/InventoryGUI.java
@@ -1,0 +1,16 @@
+package invtweaks.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface InventoryGUI {
+    // Annotation for method to get special inventory slots
+    // Signature Map<ContainerSection, List<Slot>> func()
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface ContainerSectionCallback {}
+}


### PR DESCRIPTION
Implements an API for mod authors to add the required information for compatibility themselves, instead of it needing to be manually entered into InvTweaksModCompatibility for every mod.

Example of container GUI:

``` java
import invtweaks.api.*;

@ContainerGUI
public class GuiMyContainer extends GuiContainer {
  [...]

  @ContainerGUI.RowSizeCallback
  int getRowSize() {
    return row_size;
  }

  @ContainerGUI.ContainerSectionCallback
  Map<ContainerSection, List<Slot>> getContainerSections() {
    Map<ContainerSection, List<Slot>> sections = new HashMap<>();
    sections.put(ContainerSection.CRAFTING_IN, inventorySlots.subList(0,9));
    sections.put(ContainerSection.CRAFTING_OUT, inventorySlots.subList(9, 10));
    sections.put(ContainerSection.CHEST, inventorySlots.subList(10, 20));
    return sections;
  }
}
```

InventoryGUI is similar, but lacks RowSizeCallback and is intended for non-GuiContainer screens.
