### PR TITLE
Add a persistent crafting input ContainerSection

### DIFF
--- a/src/minecraft/invtweaks/InvTweaks.java
+++ b/src/minecraft/invtweaks/InvTweaks.java
@@ -193,7 +193,7 @@ public class InvTweaks extends InvTweaksObfuscation {
 
         try {
             InvTweaksContainerSectionManager containerMgr = new InvTweaksContainerSectionManager(mc, InvTweaksContainerSection.INVENTORY);
-            
+
             // Find stack slot (look in hotbar only).
             // We're looking for a brand new stack in the hotbar
             // (not an existing stack whose amount has been increased)
@@ -540,10 +540,10 @@ public class InvTweaks extends InvTweaksObfuscation {
                             chestAlgorithm = (chestAlgorithm + 1) % 3;
                             chestAlgorithmClickTimestamp = timestamp;
 
-                        } else if(InvTweaksContainerSection.CRAFTING_IN.equals(target)) {
+                        } else if(InvTweaksContainerSection.CRAFTING_IN.equals(target) || InvTweaksContainerSection.CRAFTING_IN_PERSISTENT.equals(target)) {
                             try {
                                 new InvTweaksHandlerSorting(mc, cfgManager.getConfig(),
-                                        InvTweaksContainerSection.CRAFTING_IN,
+                                        target,
                                         InvTweaksHandlerSorting.ALGORITHM_EVEN_STACKS,
                                         (containerMgr.getSize(target) == 9) ? 3 : 2).sort();
                             } catch(Exception e) {
@@ -555,15 +555,15 @@ public class InvTweaks extends InvTweaksObfuscation {
                         		|| (InvTweaksContainerSection.INVENTORY_NOT_HOTBAR.equals(target))) {
                             handleSorting(guiScreen);
                         }
-                        
+
                     }
-                    
+
                     else if (isValidInventory(guiScreen)) {
-                        if (InvTweaksContainerSection.CRAFTING_IN.equals(target)) {
+                        if (InvTweaksContainerSection.CRAFTING_IN.equals(target) || InvTweaksContainerSection.CRAFTING_IN_PERSISTENT.equals(target)) {
                             // Crafting stacks evening
                             try {
                                 new InvTweaksHandlerSorting(mc, cfgManager.getConfig(),
-                                        InvTweaksContainerSection.CRAFTING_IN,
+                                        target,
                                         InvTweaksHandlerSorting.ALGORITHM_EVEN_STACKS,
                                         (containerMgr.getSize(target) == 9) ? 3 : 2).sort();
                             } catch (Exception e) {
@@ -610,7 +610,7 @@ public class InvTweaks extends InvTweaksObfuscation {
                 // Check for custom button texture
             	// Disabled because the current implementation requires reflection, which is difficult to manage
             	// in a MCP environment - TODO find a workaround to access the texture packs data
-                boolean customTextureAvailable = false;//hasTexture("/gui/button10px.png"); 
+                boolean customTextureAvailable = false;//hasTexture("/gui/button10px.png");
 
                 // Inventory button
                 if (!isValidChest) {

--- a/src/minecraft/invtweaks/InvTweaksContainerSection.java
+++ b/src/minecraft/invtweaks/InvTweaksContainerSection.java
@@ -17,6 +17,8 @@ public enum InvTweaksContainerSection {
     CHEST,
     /** The crafting input */
     CRAFTING_IN,
+    /** The crafting input, for containters that store it internally */
+    CRAFTING_IN_PERSISTENT,
     /** The crafting output */
     CRAFTING_OUT,
     /** The armor slots */

--- a/src/minecraft/invtweaks/InvTweaksHandlerShortcuts.java
+++ b/src/minecraft/invtweaks/InvTweaksHandlerShortcuts.java
@@ -205,8 +205,11 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
                     else if (container.hasSection(InvTweaksContainerSection.CRAFTING_IN)) {
                         orderedSections.add(InvTweaksContainerSection.CRAFTING_IN);
                     }
-                    else if (container.hasSection(InvTweaksContainerSection.FURNACE_IN)) {
-                        orderedSections.add(InvTweaksContainerSection.FURNACE_IN);
+                    else if (container.hasSection(InvTweaksContainerSection.CRAFTING_IN_PERSISTENT)) {
+                        orderedSections.add(InvTweaksContainerSection.CRAFTING_IN_PERSISTENT);
+                    }
+                    else if (container.hasSection(ContainerSection.FURNACE_IN)) {
+                        orderedSections.add(ContainerSection.FURNACE_IN);
                     }
                     else if (container.hasSection(InvTweaksContainerSection.BREWING_INGREDIENT)) {
                         ItemStack stack = container.getStack(slot);
@@ -259,6 +262,7 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
                             }
                             break;
                         case CRAFTING_IN:
+                        case CRAFTING_IN_PERSISTENT:
                         case FURNACE_IN:
                             shortcutConfig.toSection = InvTweaksContainerSection.INVENTORY_NOT_HOTBAR; break;
                         default:

--- a/src/minecraft/invtweaks/InvTweaksModCompatibility.java
+++ b/src/minecraft/invtweaks/InvTweaksModCompatibility.java
@@ -132,12 +132,12 @@ public class InvTweaksModCompatibility {
     		result.put(InvTweaksContainerSection.CHEST, slots.subList(1, slots.size() - 36));
     	}
     	else if (is(guiScreen, "GuiAdvBench")) { // RedPower 2
-            result.put(InvTweaksContainerSection.CRAFTING_IN, slots.subList(0, 9));
+            result.put(InvTweaksContainerSection.CRAFTING_IN_PERSISTENT, slots.subList(0, 9));
             result.put(InvTweaksContainerSection.CRAFTING_OUT, slots.subList(10, 11));
             result.put(InvTweaksContainerSection.CHEST, slots.subList(11, 29));
     	} else if(is(guiScreen, "GuiArcaneWorkbench") || is(guiScreen, "GuiInfusionWorkbench")) { // Thaumcraft 3
             result.put(InvTweaksContainerSection.CRAFTING_OUT, slots.subList(0, 1));
-            result.put(InvTweaksContainerSection.CRAFTING_IN, slots.subList(2, 11));
+            result.put(InvTweaksContainerSection.CRAFTING_IN_PERSISTENT, slots.subList(2, 11));
     	}
     	
 		return result;


### PR DESCRIPTION
The default inventory sort will pull items out of any slot labeled with CRAFTING_IN and place them in the inventory. While this works well enough for the vanilla crafting grids, it is a very undesired effect on many mod crafting tables which will store the items internally rather than dropping them when the UI is closed.

This commit simply adds a new category (CRAFTING_IN_PERSISTENT) which is a valid target for even-stacks code but is separate enough that the 'pull items out of crafting' code will not target it.

There are a few merge conflicts with the API PR, but those are just simple rename issues with InvTweaksContainerSection.
