### PR TITLE
Check slots are valid while moving

### DIFF
--- a/src/minecraft/invtweaks/InvTweaksContainerManager.java
+++ b/src/minecraft/invtweaks/InvTweaksContainerManager.java
@@ -160,6 +160,14 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
             return true;
         }
 
+        // Mod support -- some mods play tricks with slots to display an item but not let it be interacted with.
+        // (Specifically forestry backpack UI)
+        Slot destSlot = getSlot(destSection, destIndex);
+        if(!destSlot.isItemValid(srcStack)) {
+            return false;
+        }
+
+
         // Put hold item down
         if (getHeldStack() != null) {
             int firstEmptyIndex = getFirstEmptyIndex(InvTweaksContainerSection.INVENTORY);
@@ -181,6 +189,14 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
             InvTweaksContainerSection intermediateSection = getSlotSection(intermediateSlot);
             int intermediateIndex = getSlotIndex(intermediateSlot);
             if (intermediateIndex != -1) {
+                Slot interSlot = getSlot(intermediateSection, intermediateIndex);
+                if(!interSlot.isItemValid(destStack)) {
+                    return false;
+                }
+                Slot srcSlot = getSlot(srcSection, srcIndex);
+                if(!srcSlot.isItemValid(destStack)) {
+                    return false;
+                }
                 // Step 1/3: Dest > Int
                 leftClick(destSection, destIndex);
                 leftClick(intermediateSection, intermediateIndex);

--- a/src/minecraft/invtweaks/InvTweaksContainerManager.java
+++ b/src/minecraft/invtweaks/InvTweaksContainerManager.java
@@ -162,9 +162,11 @@ public class InvTweaksContainerManager extends InvTweaksObfuscation {
 
         // Mod support -- some mods play tricks with slots to display an item but not let it be interacted with.
         // (Specifically forestry backpack UI)
-        Slot destSlot = getSlot(destSection, destIndex);
-        if(!destSlot.isItemValid(srcStack)) {
-            return false;
+        if (destIndex != DROP_SLOT) {
+            Slot destSlot = getSlot(destSection, destIndex);
+            if(!destSlot.isItemValid(srcStack)) {
+                return false;
+            }
         }
 
 


### PR DESCRIPTION
In some situations (mostly involving mods) slots can be visible to
invtweaks but unusable. While the ModCompatiblity layer should avoid
registering these slots, mods can be volatile so this is an extra layer
of protection to avoid infinite loops.

(This is specifically prompted by a report that forestry backpacks cause errors when InvTweaks attempts to move items into the inventory slot the backpack occupies, as Forestry replaces that slot -- which can be ANY slot in the main inventory -- with a fake slot that does not accept items.)
